### PR TITLE
pref: preload web workers

### DIFF
--- a/packages/hedgehog-lab/src/compiler.ts
+++ b/packages/hedgehog-lab/src/compiler.ts
@@ -34,21 +34,21 @@ class WorkerProvider {
     }
 
     terminate() {
-        this.compilerWorker?.terminate()
-        this.outputWorker?.terminate()
+        this.compilerWorker.terminate()
+        this.outputWorker.terminate()
 
         // unlisten worker
-        this.compilerProxy?.[Comlink.releaseProxy]()
-        this.outputProxy?.[Comlink.releaseProxy]()
+        this.compilerProxy[Comlink.releaseProxy]()
+        this.outputProxy[Comlink.releaseProxy]()
     }
 }
 
-let provider = new WorkerProvider();
+let provider = new WorkerProvider()
 
 export const compiler = (...param: readonly [string, string]): any => {
     const terminate = () => {
-        provider.terminate();
-        provider = new WorkerProvider();
+        provider.terminate()
+        provider = new WorkerProvider()
     }
 
     const run = async () => {


### PR DESCRIPTION
currently, web worker scripts are requested and destroyed every time user clicks Run button, which is time consuming, and cannot be used offline. this pr introduces singleton class for workers, elevating worker scripts requests to page loading.

## performance improvement

before:

<img width="1560" alt="截屏2022-05-06 03 42 32" src="https://user-images.githubusercontent.com/85840949/167017394-7532d75f-25d6-4c89-bb1d-256a12bb5339.png">

plenty of time is wasted while requesting, parsing and compiling scripts, it takes unreasonably ~5secs to run a simple script.

after:

<img width="1680" alt="截屏2022-05-06 03 51 34" src="https://user-images.githubusercontent.com/85840949/167018082-36447ded-4742-42d9-99a4-d83c2eedecf6.png">

the running time is reduced to ~0.5secs.

workers will still be destroyed when user terminate running, but re-requests are sent immediately, following run time shouldn't be affected.
