### PR TITLE
chore(readme): add instruction about the end of the compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ yarn install
 yarn watch
 ```
 
+On each run the program compiles and it takes time. Please wait until it shows "Compiled successfully!" and an instruction about with which IP:PORT to connect.
+
 ## User Manual
 
 Hedgehog Book: [https://hedgehog-book.github.io/](https://hedgehog-book.github.io/)


### PR DESCRIPTION
The readme is confusing, when compilation takes time, no output is printed on terminal and the user tries to connect the lab per browser, as I did for hours. Hints about the compilation would help.